### PR TITLE
fix notification bug during incoming data call

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -63,11 +63,13 @@ public class PushNotification implements IPushNotification {
     }
 
     @Override
-    public void onReceived() throws InvalidNotificationException {
-        if (!mAppLifecycleFacade.isAppVisible()) {
+    public void onReceived() {
+        ReactContext reactContext = mAppLifecycleFacade.getRunningReactContext();
+        boolean hasActiveCatalystInstance = reactContext != null && reactContext.hasActiveCatalystInstance();
+        if (!mAppLifecycleFacade.isAppVisible() || !hasActiveCatalystInstance) {
             postNotification(null);
-            notifyReceivedBackgroundToJS();
-        } else {
+        }
+        if (hasActiveCatalystInstance) {
             notifyReceivedToJS();
         }
     }
@@ -130,15 +132,11 @@ public class PushNotification implements IPushNotification {
     }
 
     protected void dispatchUponVisibility() {
-        mAppLifecycleFacade.addVisibilityListener(getIntermediateAppVisibilityListener());
+        mAppLifecycleFacade.addVisibilityListener(mAppVisibilityListener);
 
         // Make the app visible so that we'll dispatch the notification opening when visibility changes to 'true' (see
         // above listener registration).
         launchOrResumeApp();
-    }
-
-    protected AppVisibilityListener getIntermediateAppVisibilityListener() {
-        return mAppVisibilityListener;
     }
 
     protected Notification buildNotification(PendingIntent intent) {


### PR DESCRIPTION
When getting incoming data call, mobile freezes. User cannot receive or reject call.
Only way to get rid of call is to force kill app from settings.
When logging we found this fatal exception: 
![Skærmbillede 2024-02-06 kl  15 37 39](https://github.com/relatel/react-native-notifications/assets/36990042/d5da471d-4561-4d7f-8859-39ee37914916)


Trying this approach fixes the bug: 
https://github.com/welldone-software/react-native-notifications/pull/5

